### PR TITLE
Raised upper bound for base library version

### DIFF
--- a/core/nyan-interpolation-core.cabal
+++ b/core/nyan-interpolation-core.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d7bdab01e5bca79d0df2d7d3f539908dabd879f2bfc7706bd8da73a7b438387a
+-- hash: 454835beb066a76fcd19ff1540bc89d3e2f2732ac9d7164ec5903d0eb782bebd
 
 name:           nyan-interpolation-core
 version:        0.9
@@ -43,10 +43,40 @@ library
       Paths_nyan_interpolation_core
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BangPatterns BlockArguments ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances FunctionalDependencies GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies UndecidableInstances ViewPatterns TypeApplications TypeOperators QuasiQuotes
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      BlockArguments
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
+      TypeOperators
+      QuasiQuotes
   ghc-options: -Weverything -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-prepositive-qualified-module -Wno-missing-safe-haskell-mode -Wno-unused-packages
   build-depends:
-      base <4.15
+      base <4.17
     , fmt
     , megaparsec
     , mtl
@@ -67,15 +97,47 @@ test-suite nyan-interpolation-core-tests
       Test.ValueInterpolators
       Tree
       Paths_nyan_interpolation_core
+  autogen-modules:
+      Paths_nyan_interpolation_core
   hs-source-dirs:
       tests
-  default-extensions: AllowAmbiguousTypes BangPatterns BlockArguments ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances FunctionalDependencies GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies UndecidableInstances ViewPatterns TypeApplications TypeOperators QuasiQuotes
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      BlockArguments
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
+      TypeOperators
+      QuasiQuotes
   ghc-options: -Weverything -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-prepositive-qualified-module -Wno-missing-safe-haskell-mode -Wno-unused-packages
   build-tool-depends:
       tasty-discover:tasty-discover
   build-depends:
       HUnit
-    , base <4.15
+    , base <4.17
     , fmt
     , megaparsec
     , mtl

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -19,7 +19,7 @@ default-extensions: *default-extensions
 ghc-options: *ghc-options
 
 dependencies:
-  - base <4.15
+  - base <4.17
   - fmt
   - megaparsec
   - mtl

--- a/full/nyan-interpolation.cabal
+++ b/full/nyan-interpolation.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 191c85a1a5dfccaa3abfb718b94a0a57cdb576f10a674129e73519fc12ed58c6
+-- hash: a77f2eae2cfd2c173f77963a2f6af54c0547b52b2841f478fa358fb6756a163c
 
 name:           nyan-interpolation
 version:        0.9
@@ -36,10 +36,40 @@ library
       Paths_nyan_interpolation
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BangPatterns BlockArguments ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances FunctionalDependencies GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies UndecidableInstances ViewPatterns TypeApplications TypeOperators QuasiQuotes
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      BlockArguments
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
+      TypeOperators
+      QuasiQuotes
   ghc-options: -Weverything -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-prepositive-qualified-module -Wno-missing-safe-haskell-mode -Wno-unused-packages
   build-depends:
-      base <4.15
+      base <4.17
     , fmt
     , haskell-src-exts
     , haskell-src-meta
@@ -56,15 +86,47 @@ test-suite nyan-interpolation-tests
       Test.ShowInterpolator
       Tree
       Paths_nyan_interpolation
+  autogen-modules:
+      Paths_nyan_interpolation
   hs-source-dirs:
       tests
-  default-extensions: AllowAmbiguousTypes BangPatterns BlockArguments ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances FunctionalDependencies GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies UndecidableInstances ViewPatterns TypeApplications TypeOperators QuasiQuotes
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      BlockArguments
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
+      TypeOperators
+      QuasiQuotes
   ghc-options: -Weverything -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-prepositive-qualified-module -Wno-missing-safe-haskell-mode -Wno-unused-packages
   build-tool-depends:
       tasty-discover:tasty-discover
   build-depends:
       HUnit
-    , base <4.15
+    , base <4.17
     , fmt
     , haskell-src-exts
     , haskell-src-meta

--- a/full/package.yaml
+++ b/full/package.yaml
@@ -19,7 +19,7 @@ default-extensions: *default-extensions
 ghc-options: *ghc-options
 
 dependencies:
-  - base <4.15
+  - base <4.17
   - fmt  # need a direct dep to link things in haddock
   - haskell-src-exts
   - haskell-src-meta

--- a/simple/nyan-interpolation-simple.cabal
+++ b/simple/nyan-interpolation-simple.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0f7a41cfc7a9c3228fd7625e552435da154d7ae3a5876db08ecf3348848f79a2
+-- hash: 3ec4653947d7d52aad6fc03fff069713840f6b334e560a138a0906d8b6b94155
 
 name:           nyan-interpolation-simple
 version:        0.9
@@ -34,10 +34,40 @@ library
       Paths_nyan_interpolation_simple
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BangPatterns BlockArguments ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances FunctionalDependencies GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies UndecidableInstances ViewPatterns TypeApplications TypeOperators QuasiQuotes
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      BlockArguments
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
+      TypeOperators
+      QuasiQuotes
   ghc-options: -Weverything -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-implicit-prelude -Wno-prepositive-qualified-module -Wno-missing-safe-haskell-mode -Wno-unused-packages
   build-depends:
-      base <4.15
+      base <4.17
     , nyan-interpolation-core
     , text
   default-language: Haskell2010

--- a/simple/package.yaml
+++ b/simple/package.yaml
@@ -20,7 +20,7 @@ default-extensions: *default-extensions
 ghc-options: *ghc-options
 
 dependencies:
-  - base <4.15
+  - base <4.17
   - nyan-interpolation-core
   - text
 


### PR DESCRIPTION
Wanted to use this library on GHC 9.2.2, but wasn't able to due to the version bounds. I've tested it locally after modifying the version bounds to include base 4.16, and it works. 